### PR TITLE
Feature/combine search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+.idea/misc.xml
+.idea/inspectionProfiles*
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+ *.iml
+ modules.xml
+
+#jupyter checkpoints
+.ipynb_checkpoints*

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Elastic-Search-with-sBERT-Model.iml
+++ b/.idea/Elastic-Search-with-sBERT-Model.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Elastic-Search-with-sBERT-Model.iml" filepath="$PROJECT_DIR$/.idea/Elastic-Search-with-sBERT-Model.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.ipynb_checkpoints/DataIndex-checkpoint.ipynb
+++ b/.ipynb_checkpoints/DataIndex-checkpoint.ipynb
@@ -7,8 +7,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from elasticsearch import Elasticsearch\n",
-    "from elasticsearch.helpers import bulk"
+    "from elasticsearch import Elasticsearch"
    ]
   },
   {
@@ -200,8 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"VectorDescription\"] = df[\"Description\"].apply(lambda x: model.encode(x))\n",
-    "# here, maybe convert embeddings to lists, to work with serializable data in JSON"
+    "df[\"VectorDescription\"] = df[\"Description\"].apply(lambda x: model.encode(x))"
    ]
   },
   {
@@ -477,13 +475,7 @@
     }
    ],
    "source": [
-    "# can't change mapping for existing fields. \n",
-    "# i delete and recreate the index\n",
-    "\n",
-    "if elastics.indices.exists(index=\"clothing\"):\n",
-    "    elastics.indices.delete(index=\"clothing\")\n",
-    "\n",
-    "elastics.indices.create(index=\"clothing\", mapping=mapping)"
+    "elastics.indices.create(index=\"clothing\", mappings=mapping)"
    ]
   },
   {
@@ -492,7 +484,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#record_list = df.to_dict('records')"
+    "record_list = df.to_dict('records')"
    ]
   },
   {
@@ -501,25 +493,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#for record in record_list:\n",
-    "    #elastics.index(index='clothing', document = record, id=record[\"ProductID\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def generate_actions(df):\n",
-    "    for record in df.to_dict(\"records\"):\n",
-    "        yield {\n",
-    "            \"_index\":\"clothing\",\n",
-    "            \"_id\": record[\"ProductID\"],\n",
-    "            \"_source\":record\n",
-    "        }\n",
-    "\n",
-    "bulk(elastics, generate_actions(df))"
+    "for record in record_list:\n",
+    "    elastics.index(index='clothing', document = record, id=record[\"ProductID\"])"
    ]
   },
   {
@@ -585,12 +560,8 @@
     "    \"field\": \"VectorDescription\",\n",
     "    \"query_vector\": embedding,\n",
     "    \"k\":2,\n",
-    "    \"num_candidates\":1000, #larger dataset\n",
-    "    \"ef_search\":50 #tradeoff between accuracy and query speed, adjust as needed\n",
-    "    \n",
+    "    \"num_candidates\" : 500\n",
     "}\n",
-    "\n",
-    "#we would have to systematically fine tune m, ef_construction, and ef_search along with the other parameters\n",
     "\n",
     "result= elastics.knn_search(index='clothing',knn=query, source=[\"ProductName\", \"Description\"])\n",
     "result[\"hits\"][\"hits\"]"
@@ -599,7 +570,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "helpful",
    "language": "python",
    "name": "python3"
   },
@@ -613,9 +584,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/DataIndex.ipynb
+++ b/DataIndex.ipynb
@@ -191,7 +191,7 @@
    ],
    "source": [
     "from sentence_transformers import SentenceTransformer\n",
-    "model = SentenceTransformer(\"all-mpnet-base-v2\")"
+    "model = SentenceTransformer(\"all-mpnet-base-v2\") #load fine-tuned model"
    ]
   },
   {

--- a/IndexMapping.py
+++ b/IndexMapping.py
@@ -32,7 +32,7 @@ mapping = {
         "type":"dense_vector",
         "dims":768,
         "index":True,
-        "similarity": "l2_norm",
+        "similarity": "cosine",
         "index_options": {
             "type":"hnsw", # approximate nearest neighbor for search speed, useful in larger datasets
             "m":16, # num of biirectional links.

--- a/IndexMapping.py
+++ b/IndexMapping.py
@@ -32,7 +32,12 @@ mapping = {
         "type":"dense_vector",
         "dims":768,
         "index":True,
-        "similarity": "l2_norm"
+        "similarity": "l2_norm",
+        "index_options": {
+            "type":"hnsw", # approximate nearest neighbor for search speed, useful in larger datasets
+            "m":16, # num of biirectional links.
+            "ef_construction": 100 # recall during index construction
+        }
     }
 }
 

--- a/sBERT-Tuning.py
+++ b/sBERT-Tuning.py
@@ -1,0 +1,25 @@
+from sentence_transformers import SentenceTransformer, InputExample, losses
+from torch.utils.data import DataLoader
+import csv
+
+model = SentenceTransformer("all-mpnet-base-v2")
+
+train_examples = []
+with open('training_data.csv', 'r') as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        train_examples.append(InputExample(
+            texts = [row["sentence1"], row["sentence2"]],
+            label = float(row("label"))
+        ))
+
+train_dataloader = DataLoader(train_examples, shuffle=True, batch_size=16)
+train_loss = losses.CosineSimilarityLoss(model)
+
+# fine-tune to a domain/use-specific dataset
+model.fit(
+    train_objectives=[(train_dataloader, train_loss)],
+    epochs=1,
+    warmup_steps=100,
+    output_path="fine_tuned_model"
+)

--- a/searchapp.py
+++ b/searchapp.py
@@ -2,6 +2,7 @@ import streamlit as st
 from elasticsearch import Elasticsearch
 from sentence_transformers import SentenceTransformer
 
+
 indexName = "all_products"
 
 USERNAME_AUTH="junior"
@@ -21,22 +22,40 @@ else:
     print("Can not connect to Elasticsearch!")
 
 
-
-
 def search(input_keyword):
-    model = SentenceTransformer('all-mpnet-base-v2')
+    model = SentenceTransformer('all-mpnet-base-v2') #load fine-tuned model
     vector_of_input_keyword = model.encode(input_keyword)
 
     query = {
-        "field": "VectorDescription",
-        "query_vector": vector_of_input_keyword,
-        "k": 5,
-        "num_candidates": 1000
+        "size":5,
+        "query": {
+            "function_score": {
+                "query": {
+                    "multi_match": { # keyword search on specified fields
+                        "query": input_keyword,
+                        "fields": ["ProductName^2", "ProductBrand", "PrimaryColor"]
+                    }
+                }
+                "functions":[
+                    {
+                        "script_score": { # calculates similarity score between query vector and doc vectors.
+                            "script": {
+                                "source": "cosineSimilarity(params.query_vector, 'VectorDescription') + 1.0",
+                                "params": {
+                                    "query_vector": vector_of_input_keyword
+                                }
+                            }
+                        }
+                    }
+                ],
+                "boost_mode": "sum", # combine original query score and function score
+                "score_mode": "sum"
+            }
+        },
+        "_source": ["ProductName", "Description"]
     }
-    res = es.knn_search(index="clothing"
-                        , knn=query 
-                        , source=["ProductName","Description"]
-                        )
+
+    res = es.search(index="clothing", body=query)
     results = res["hits"]["hits"]
 
     return results


### PR DESCRIPTION
Implemented possibility of combining current semantic vector search with keyword matching. Changed mapping to use cosine similarity. 'multi_match' for keyword search on specific fields and 'script_score' for similarity between vector queries and vector documents. 

It would be benefitial to craft a use-specific dataset summarizing semantic comparisons between industry's vocabularies, for instance (a dataset with "sentence1", "sentence2", and "similarity_label", to then fine tune the BERT model or any other. I implemented a very brief demo on how this would be done, assuming such a dataset.